### PR TITLE
test(e2e): Exclude inbox creation during development

### DIFF
--- a/packages/e2e/.env.sample
+++ b/packages/e2e/.env.sample
@@ -6,3 +6,8 @@ MAILSLURP_API_KEY=''
 USER_POOL_ID=''
 AWS_ACCESS_KEY_ID=''
 AWS_SECRET_ACCESS_KEY=''
+
+# If test user is set with a valid user email address
+# Then the E2E tests will run with that user rather than creating/destroying a random one every time
+# Use this for development only to avoid creating new email inboxes all the time
+# TEST_USER='YOUR_TEST_EMAIL_ADDRESS_HERE'

--- a/packages/e2e/env-keys.ts
+++ b/packages/e2e/env-keys.ts
@@ -10,4 +10,5 @@ export const envConfig = {
   INVALID_USER: 'invalid@user.com',
   INVALID_PASSWORD: 'password000',
   MAILSLURP_API_KEY: process.env.MAILSLURP_API_KEY || '',
+  TEST_USER: process.env.TEST_USER || '',
 };

--- a/packages/e2e/features/register.feature
+++ b/packages/e2e/features/register.feature
@@ -3,7 +3,7 @@ Feature: Register
   I should be able to register a new Online Scoreboard account
   So that I can log in and start interacting with the app
 
-@register
+@register  @createNewUser
 Scenario: Register with invalid password
   Given I am on the Online Scoreboard registration form
   When I fill in the registration form with 'valid' email address and 'invalid' password for user 'test1'
@@ -24,7 +24,7 @@ Scenario: Register with existing email address
   Then I should see a 'error' notification saying 'An account with the given email already exists.'
   And I should see the registration form
 
-@register
+@register @createNewUser
 Scenario: Register with correct credentials
   Given I am on the Online Scoreboard registration form
   When I fill in the registration form with 'valid' email address and 'valid' password for user 'test3'

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -9,8 +9,7 @@
   "private": true,
   "scripts": {
     "start": "cucumber-js --require-module ts-node/register './features/' --require './step_definitions/*.ts' --require './support/*.ts' -f json:reporting/json/json-report.json --format summary",
-    "local": "cucumber-js --require-module ts-node/register './features/' --require './step_definitions/*.ts' --require './support/*.ts'",
-    "local:login": "yarn local --tags=@login",
+    "local": "cucumber-js --require-module ts-node/register './features/' --require './step_definitions/*.ts' --require './support/*.ts' --tags 'not @createNewUser'",
     "cucumber-js": "cucumber-js",
     "report": "ts-node reporter.ts",
     "lint": "eslint --ext=ts,tsx {pages,support,step_definitions}/**/*",

--- a/packages/e2e/step_definitions/login.step.ts
+++ b/packages/e2e/step_definitions/login.step.ts
@@ -43,7 +43,7 @@ Then(/^I enter '(.*)' login credentials$/, async function(credentialsType: strin
     await username.sendKeys(envConfig.INVALID_USER);
     await password.sendKeys(envConfig.INVALID_PASSWORD);
   } else if (credentialsType === 'correct') {
-    await username.sendKeys(TestRunContext.getTestUser().address);
+    await username.sendKeys(TestRunContext.getTestUser());
     await password.sendKeys(envConfig.VALID_PASSWORD);
   } else {
     const email = TestRunContext.getUserEmail(credentialsType);
@@ -62,7 +62,7 @@ When(/^I am a logged in Online Scoreboard user$/, async function() {
   const password = await this.browser.findElement(LoginPage.getPasswordInput());
   const loginButton = await this.browser.findElement(LoginPage.getLoginButton());
 
-  await username.sendKeys(TestRunContext.getTestUser().address);
+  await username.sendKeys(TestRunContext.getTestUser());
   await password.sendKeys(envConfig.VALID_PASSWORD);
 
   await loginButton.click();

--- a/packages/e2e/step_definitions/registration.step.ts
+++ b/packages/e2e/step_definitions/registration.step.ts
@@ -63,7 +63,7 @@ Then(/^I fill in the registration form with '(.*)' email address and '(.*)' pass
 
     await username.sendKeys(inbox.address);
   } else if (isValidEmail === 'existing') {
-    await username.sendKeys(TestRunContext.getTestUser().address);
+    await username.sendKeys(TestRunContext.getTestUser());
   } else {
     await username.sendKeys('invalidEmailAddress');
   }

--- a/packages/e2e/support/test-run-context.ts
+++ b/packages/e2e/support/test-run-context.ts
@@ -1,5 +1,6 @@
 import { BrowserCapabilities } from './browser-capabilities';
 import { WebDriver } from 'selenium-webdriver';
+import { envConfig } from '../env-keys';
 import {
   TestUser,
   Inbox,
@@ -27,7 +28,9 @@ export class TestRunContext {
   }
 
   public static async createTestUser(): Promise<void> {
-    this.testUser = await createTestUser();
+    if (!envConfig.TEST_USER) {
+      this.testUser = await createTestUser();
+    }
   }
 
   public static async destroyTestUsers(): Promise<void> {
@@ -41,8 +44,12 @@ export class TestRunContext {
     }
   }
 
-  public static getTestUser(): TestUser {
-    return this.testUser;
+  public static getTestUser(): string {
+    if (envConfig.TEST_USER) {
+      return envConfig.TEST_USER;
+    }
+
+    return this.testUser.address;
   }
 
   public static async generateNewInbox(tag?: string) {


### PR DESCRIPTION
When running E2E locally, avoid creating new mail inboxes and use a test
account instead, when provided.

For this to work, a new `TEST_USER` environment variable has been
introduced. The user will need to manually set this to their registered Online Scoreboard email address before running the tests

Run the tests locally with `yarn e2e:local` will automatically exclude all the scenarios tagged with `@createNewUser`